### PR TITLE
Allow menu bar icon to be hidden, optimize a little

### DIFF
--- a/ClearMenuBar/AppDelegate.swift
+++ b/ClearMenuBar/AppDelegate.swift
@@ -92,6 +92,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
+    // If the menu bar item was hidden, and the user reopens the app while it's running, show the menu bar item again.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if statusItem?.isVisible == false {
+            statusItem?.isVisible = true
+        }
+        return true
+    }
+
     func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
     }

--- a/ClearMenuBar/AppDelegate.swift
+++ b/ClearMenuBar/AppDelegate.swift
@@ -62,6 +62,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             statusItem?.button?.image = image.withSymbolConfiguration(config)
         }
         
+        statusItem?.behavior = .removalAllowed
+
         if let menu = menu {
             statusItem?.menu = menu
         }

--- a/ClearMenuBar/BackdropLayer/BackdropLayerView.swift
+++ b/ClearMenuBar/BackdropLayer/BackdropLayerView.swift
@@ -611,8 +611,6 @@ extension CGImage {
     func resize(width: Int, height: Int) -> CGImage? {
         guard width > 0, height > 0 else { return nil }
 
-        let rep = NSBitmapImageRep(cgImage: self)
-
         let colorSpace = CGColorSpaceCreateDeviceRGB()
 
         guard let context = CGContext(
@@ -630,10 +628,7 @@ extension CGImage {
 
         context.interpolationQuality = .high
 
-        context.draw(
-            rep.cgImage!,
-            in: CGRect(x: 0, y: 0, width: width, height: height)
-        )
+        context.draw(self, in: CGRect(x: 0, y: 0, width: width, height: height))
 
         return context.makeImage()
     }

--- a/ClearMenuBar/LogStreamDelegate.swift
+++ b/ClearMenuBar/LogStreamDelegate.swift
@@ -11,14 +11,13 @@ class LogStreamDelegate: LogStreamDelegateProtocol {
     
     private var isLocked: Bool = false
     private let lockDuration: TimeInterval = 0.25
+    private let regex = try! NSRegularExpression(pattern: "url: (file://[^,]+)", options: [])
     
     func newLogEntry(entry: BHSwiftOSLogStream.LogEntry, history: BHSwiftOSLogStream.History<BHSwiftOSLogStream.LogEntry>) {
         
         guard (entry.description.contains("BEGIN - Image cache lookup - url: file")) else { return }
         
         guard (!isLocked) else { return }
-        
-        let regex = try! NSRegularExpression(pattern: "url: (file://[^,]+)", options: [])
         
         let matches = regex.matches(in: entry.message, options: [], range: NSRange(location: 0, length: entry.message.utf16.count))
             

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 - Supports single wallpaper or multiple wallpapers from a folder;
 - Supports light and dark mode.
+- The menu bar icon can be hidden by dragging it out. To bring it back, relaunch the app while it is already running.
 
 ## Feature Support
 


### PR DESCRIPTION
Allows folks to hide the menu bar icon by dragging it out. 
To bring it back, they can relaunch the app while it's currently running to restore the menu bar icon.


https://github.com/user-attachments/assets/5b9ef972-8eac-4521-b858-4b9a95912fa1

Also, added two nit optimizations:
- Avoid rebuilding the regex each time
- Avoid making a intermediary image 

Tested on MacOs Sequoia
